### PR TITLE
Tracing: Attach correlationId to headers of requests and log

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext{
     pmdVersion = '5.6.1'
     jacocoVersion = '0.8.5'
     findbugsVersion = '3.0.1'
-    commercetoolsJvmSdkVersion = '1.48.0'
+    commercetoolsJvmSdkVersion = '1.49.0'
     logStashLogbackEncoderVersion = '6.3'
     logbackClassicVersion = '1.2.3'
     julToSlf4jVersion = '1.7.30'
@@ -43,8 +43,6 @@ dependencies {
     implementation "com.commercetools.sdk.jvm.core:commercetools-java-client:${commercetoolsJvmSdkVersion}"
     implementation "com.commercetools.sdk.jvm.core:commercetools-convenience:${commercetoolsJvmSdkVersion}"
     implementation "net.logstash.logback:logstash-logback-encoder:${logStashLogbackEncoderVersion}"
-    // TODO: remove when JVM SDK is bumped tp 1.49.0
-    implementation "com.heshammassoud:commercetools-correlation-id-decorator:0.1.0"
     // ch.qos.logback:logback-classic is excluded from the unit and integration test classpath in /junit-tests.gradle
     implementation "ch.qos.logback:logback-classic:${logbackClassicVersion}"
     implementation "org.slf4j:jul-to-slf4j:${julToSlf4jVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     implementation "com.commercetools.sdk.jvm.core:commercetools-java-client:${commercetoolsJvmSdkVersion}"
     implementation "com.commercetools.sdk.jvm.core:commercetools-convenience:${commercetoolsJvmSdkVersion}"
     implementation "net.logstash.logback:logstash-logback-encoder:${logStashLogbackEncoderVersion}"
+    // TODO: remove when JVM SDK is bumped tp 1.49.0
+    implementation "com.heshammassoud:commercetools-correlation-id-decorator:0.1.0"
     // ch.qos.logback:logback-classic is excluded from the unit and integration test classpath in /junit-tests.gradle
     implementation "ch.qos.logback:logback-classic:${logbackClassicVersion}"
     implementation "org.slf4j:jul-to-slf4j:${julToSlf4jVersion}"

--- a/gradle-scripts/repositories.gradle
+++ b/gradle-scripts/repositories.gradle
@@ -1,7 +1,3 @@
 repositories {
     mavenCentral()
-    maven {
-        // TODO: remove when JVM SDK is bumped tp 1.49.0
-        url "https://dl.bintray.com/heshammassoud/maven/"
-    }
 }

--- a/gradle-scripts/repositories.gradle
+++ b/gradle-scripts/repositories.gradle
@@ -1,3 +1,7 @@
 repositories {
     mavenCentral()
+    maven {
+        // TODO: remove when JVM SDK is bumped tp 1.49.0
+        url "https://dl.bintray.com/heshammassoud/maven/"
+    }
 }

--- a/src/main/java/com/commercetools/emailprocessor/email/EmailProcessor.java
+++ b/src/main/java/com/commercetools/emailprocessor/email/EmailProcessor.java
@@ -47,7 +47,7 @@ public class EmailProcessor {
     static final String PARAM_TENANT_ID = "tenantid";
     private static final String ENCRYPTION_ALGORITHM = "Blowfish";
     /**
-     * Limited thread pool where to execute {@link #callApiEndpoint(String, TenantConfiguration, String)} and all
+     * Limited thread pool where to execute {@link #callApiEndpoint(String, TenantConfiguration)} and all
      * chained post processor. For now limited for up to 8 parallel requests.
      */
     private static final Executor callApiThreadPool = Executors.newWorkStealingPool(8);
@@ -75,7 +75,7 @@ public class EmailProcessor {
         final Statistics statistics = new Statistics(tenantConfig.getProjectKey());
 
         final Function<CustomObject<JsonNode>, CompletableFuture<Void>> customObjectMapper = customObject ->
-                callApiEndpoint(customObject.getId(), tenantConfig, getFromMDCOrGenerateNew())
+                callApiEndpoint(customObject.getId(), tenantConfig)
                         .thenAccept(statistics::update)
                         .toCompletableFuture();
 
@@ -106,12 +106,11 @@ public class EmailProcessor {
      */
     CompletableFuture<Integer> callApiEndpoint(
         @Nonnull final String customObjectId,
-        @Nonnull final TenantConfiguration tenantConfiguration,
-        @Nonnull final String correlationId) {
+        @Nonnull final TenantConfiguration tenantConfiguration) {
 
         return CompletableFuture.supplyAsync(() -> {
             final HttpPost httpPost = tenantConfiguration.getHttpPost();
-            httpPost.addHeader(HttpHeaders.X_CORRELATION_ID, correlationId);
+            httpPost.addHeader(HttpHeaders.X_CORRELATION_ID, getFromMDCOrGenerateNew());
 
             final List<NameValuePair> params = new ArrayList<>();
             try {

--- a/src/main/java/com/commercetools/emailprocessor/email/EmailProcessor.java
+++ b/src/main/java/com/commercetools/emailprocessor/email/EmailProcessor.java
@@ -34,7 +34,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.function.Function;
 
-import static com.commercetools.emailprocessor.utils.CorrelationIdUtils.getFromMDCOrGenerateNew;
+import static com.commercetools.emailprocessor.utils.CorrelationIdUtils.getFromMdcOrGenerateNew;
 import static io.sphere.sdk.queries.QueryExecutionUtils.queryAll;
 import static java.lang.String.format;
 import static java.util.concurrent.CompletableFuture.allOf;
@@ -110,7 +110,7 @@ public class EmailProcessor {
 
         return CompletableFuture.supplyAsync(() -> {
             final HttpPost httpPost = tenantConfiguration.getHttpPost();
-            httpPost.addHeader(HttpHeaders.X_CORRELATION_ID, getFromMDCOrGenerateNew());
+            httpPost.addHeader(HttpHeaders.X_CORRELATION_ID, getFromMdcOrGenerateNew());
 
             final List<NameValuePair> params = new ArrayList<>();
             try {

--- a/src/main/java/com/commercetools/emailprocessor/email/EmailProcessor.java
+++ b/src/main/java/com/commercetools/emailprocessor/email/EmailProcessor.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import io.sphere.sdk.client.SphereClient;
 import io.sphere.sdk.customobjects.CustomObject;
 import io.sphere.sdk.customobjects.queries.CustomObjectQuery;
+import io.sphere.sdk.http.HttpHeaders;
 import io.sphere.sdk.queries.QueryPredicate;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.http.NameValuePair;
@@ -33,6 +34,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.function.Function;
 
+import static com.commercetools.emailprocessor.utils.CorrelationIdUtils.getFromMDCOrGenerateNew;
 import static io.sphere.sdk.queries.QueryExecutionUtils.queryAll;
 import static java.lang.String.format;
 import static java.util.concurrent.CompletableFuture.allOf;
@@ -45,8 +47,8 @@ public class EmailProcessor {
     static final String PARAM_TENANT_ID = "tenantid";
     private static final String ENCRYPTION_ALGORITHM = "Blowfish";
     /**
-     * Limited thread pool where to execute {@link #callApiEndpoint(String, TenantConfiguration)} and all chained post
-     * processor. For now limited for up to 8 parallel requests.
+     * Limited thread pool where to execute {@link #callApiEndpoint(String, TenantConfiguration, String)} and all
+     * chained post processor. For now limited for up to 8 parallel requests.
      */
     private static final Executor callApiThreadPool = Executors.newWorkStealingPool(8);
     private static final Logger LOG = LoggerFactory.getLogger(EmailProcessor.class);
@@ -73,15 +75,16 @@ public class EmailProcessor {
         final Statistics statistics = new Statistics(tenantConfig.getProjectKey());
 
         final Function<CustomObject<JsonNode>, CompletableFuture<Void>> customObjectMapper = customObject ->
-                callApiEndpoint(customObject.getId(), tenantConfig)
+                callApiEndpoint(customObject.getId(), tenantConfig, getFromMDCOrGenerateNew())
                         .thenAccept(statistics::update)
                         .toCompletableFuture();
 
 
         // 1. Query for all custom objects and map each to the future chain above.
         // 2. Map the list of future to an allOf future to execute them in parallel.
+        // TODO: Need to pass correlation id here to queryAll
         return queryAll(client, query, customObjectMapper)
-                .thenCompose(stages -> allOf(stages.toArray(new CompletableFuture[stages.size()])))
+                .thenCompose(stages -> allOf(stages.toArray(new CompletableFuture[0])))
                 .handle(((voidResult, exception) -> {
                     client.close();
                     if (exception != null) {
@@ -101,10 +104,15 @@ public class EmailProcessor {
      * @param tenantConfiguration Configuration of the current tenant
      * @return Http Status code response code of the current request
      */
-    CompletableFuture<Integer> callApiEndpoint(@Nonnull final String customObjectId,
-                                               @Nonnull final TenantConfiguration tenantConfiguration) {
+    CompletableFuture<Integer> callApiEndpoint(
+        @Nonnull final String customObjectId,
+        @Nonnull final TenantConfiguration tenantConfiguration,
+        @Nonnull final String correlationId) {
+
         return CompletableFuture.supplyAsync(() -> {
             final HttpPost httpPost = tenantConfiguration.getHttpPost();
+            httpPost.addHeader(HttpHeaders.X_CORRELATION_ID, correlationId);
+
             final List<NameValuePair> params = new ArrayList<>();
             try {
                 final String encryptedCustomerId = blowFish(customObjectId, tenantConfiguration.getEncryptionKey(),

--- a/src/main/java/com/commercetools/emailprocessor/jobs/EmailJob.java
+++ b/src/main/java/com/commercetools/emailprocessor/jobs/EmailJob.java
@@ -4,6 +4,7 @@ import com.commercetools.emailprocessor.model.ProjectConfiguration;
 import com.commercetools.emailprocessor.model.Statistics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import javax.annotation.Nonnull;
 import java.util.List;
@@ -37,6 +38,7 @@ public class EmailJob {
                                 LOG.error(String.format("Error in email processing for tenant %s.",
                                         tenantConfiguration.getProjectKey()), exception);
                             }
+                            MDC.clear();
                             return CompletableFuture.completedFuture(Statistics.ofError(tenantConfiguration
                                     .getProjectKey()));
                         }

--- a/src/main/java/com/commercetools/emailprocessor/utils/CorrelationIdUtils.java
+++ b/src/main/java/com/commercetools/emailprocessor/utils/CorrelationIdUtils.java
@@ -1,0 +1,23 @@
+package com.commercetools.emailprocessor.utils;
+import org.slf4j.MDC;
+import java.util.UUID;
+
+import static java.util.Optional.ofNullable;
+
+public final class CorrelationIdUtils {
+    private static final String CORRELATION_ID_LOG_VAR_NAME = "correlationId";
+
+    public static String getFromMDCOrGenerateNew() {
+        return ofNullable(MDC.get(CORRELATION_ID_LOG_VAR_NAME))
+            .orElseGet(CorrelationIdUtils::generateUniqueCorrelationIdAndAddToMDC);
+    }
+
+    private static String generateUniqueCorrelationIdAndAddToMDC() {
+        final String correlationId = UUID.randomUUID().toString();
+        MDC.put(CORRELATION_ID_LOG_VAR_NAME, correlationId);
+        return correlationId;
+    }
+
+    private CorrelationIdUtils() {
+    }
+}

--- a/src/main/java/com/commercetools/emailprocessor/utils/CorrelationIdUtils.java
+++ b/src/main/java/com/commercetools/emailprocessor/utils/CorrelationIdUtils.java
@@ -1,4 +1,5 @@
 package com.commercetools.emailprocessor.utils;
+
 import org.slf4j.MDC;
 import java.util.UUID;
 
@@ -7,12 +8,12 @@ import static java.util.Optional.ofNullable;
 public final class CorrelationIdUtils {
     private static final String CORRELATION_ID_LOG_VAR_NAME = "correlationId";
 
-    public static String getFromMDCOrGenerateNew() {
+    public static String getFromMdcOrGenerateNew() {
         return ofNullable(MDC.get(CORRELATION_ID_LOG_VAR_NAME))
-            .orElseGet(CorrelationIdUtils::generateUniqueCorrelationIdAndAddToMDC);
+            .orElseGet(CorrelationIdUtils::generateUniqueCorrelationIdAndAddToMdc);
     }
 
-    private static String generateUniqueCorrelationIdAndAddToMDC() {
+    private static String generateUniqueCorrelationIdAndAddToMdc() {
         final String correlationId = UUID.randomUUID().toString();
         MDC.put(CORRELATION_ID_LOG_VAR_NAME, correlationId);
         return correlationId;

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -10,6 +10,7 @@ As such, enabling logback status data is very highly recommended and should be c
             <providers>
                 <message/>
                 <arguments/>
+                <mdc/>
                 <logstashMarkers/>
                 <!-- Some fields are mapped to camel-case for consistency -->
                 <timestamp>


### PR DESCRIPTION
1. Adds correlation ids to requests header going to upstream services (CTP)
2. Puts the correlation ids in the MDC for logging coming from the downstream services or generates one.